### PR TITLE
Add a viewlet that warns the admins that the site is using collective.regenv

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added a viewlet that warns the admins that the site is using collective.regenv
+  [ale-rt]
 
 
 1.0.0 (2023-11-15)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,17 +6,7 @@ ignore =
     .gitattributes
 
 [isort]
-# black compatible isort rules:
-force_alphabetical_sort = True
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses = True
-lines_after_imports = 2
-line_length = 88
-not_skip =
-    __init__.py
-skip =
+profile = plone
 
 [flake8]
 # black compatible flake8 rules:

--- a/src/collective/regenv/browser.py
+++ b/src/collective/regenv/browser.py
@@ -1,0 +1,38 @@
+from collective.regenv import _
+from collective.regenv import registry
+from plone import api
+from plone.app.layout.viewlets.common import ViewletBase
+from Products.Five import BrowserView
+
+
+COLLECTIVE_REGENV_ACKNOWLEDGED = "collective_regenv_acknowledged"
+
+
+class AcknowledgeCollectiveRegenv(BrowserView):
+    def __call__(self):
+        """When this is called set a cookie that will be used to hide the viewlet."""
+        self.request.response.setCookie(
+            COLLECTIVE_REGENV_ACKNOWLEDGED, "true", max_age=604800
+        )
+        api.portal.show_message(message=_("Ok!"), request=self.request, type="info")
+        return self.request.response.redirect(self.context.absolute_url())
+
+
+class RegenvViewlet(ViewletBase):
+    """Viewlet for rendering the registration environment."""
+
+    def available(self):
+        """Check if the viewlet should be displayed."""
+        if not registry:
+            return False
+
+        if self.request.cookies.get(COLLECTIVE_REGENV_ACKNOWLEDGED):
+            return False
+
+        # Check if there is some override active on this site
+        portal_path = "/".join(api.portal.get().getPhysicalPath())
+        for key in registry:
+            if key.startswith(portal_path):
+                return True
+
+        return False

--- a/src/collective/regenv/configure.zcml
+++ b/src/collective/regenv/configure.zcml
@@ -1,8 +1,25 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
-    i18n_domain="collective.regenv">
+    i18n_domain="untranslated"
+    >
+
+  <browser:page
+      name="acknowledge_collective_regenv"
+      for="*"
+      class=".browser.AcknowledgeCollectiveRegenv"
+      permission="cmf.ManagePortal"
+      />
+
+  <browser:viewlet
+      name="collective.regenv.viewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContentTitle"
+      class=".browser.RegenvViewlet"
+      template="templates/viewlet.pt"
+      permission="cmf.ManagePortal"
+      />
 
 </configure>

--- a/src/collective/regenv/templates/viewlet.pt
+++ b/src/collective/regenv/templates/viewlet.pt
@@ -1,0 +1,24 @@
+<dl class="portalMessage warning"
+    role="status"
+    tal:condition="view/available"
+    i18n:domain="collective.regenv"
+>
+  <dt></dt>
+  <dd>
+    <tal:i18n i18n:translate="message_collective_regenv_active">
+      <a class="external-link"
+         href="https://pypi.org/project/collective.regenv/"
+         target="_blank"
+         i18n:name="collective_regenv"
+      >
+        collective.regenv
+      </a>
+      is active on this site.
+    </tal:i18n>
+    <a href="${here/portal_url}/@@acknowledge_collective_regenv"
+       i18n:translate="label_dismiss"
+    >
+      Dismiss this message.
+    </a>
+  </dd>
+</dl>

--- a/src/collective/regenv/tests/test_browser.py
+++ b/src/collective/regenv/tests/test_browser.py
@@ -1,0 +1,54 @@
+from collective.regenv.browser import COLLECTIVE_REGENV_ACKNOWLEDGED
+from collective.regenv.browser import RegenvViewlet
+from collective.regenv.testing import COLLECTIVE_REGISTRY_INTEGRATION_TESTING
+from plone import api
+from unittest import mock
+
+import unittest
+
+
+class TestBrowser(unittest.TestCase):
+    layer = COLLECTIVE_REGISTRY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        self.viewlet = RegenvViewlet(self.portal, self.request, None, None)
+
+    def test_viewlet_no_overrides(self):
+        self.assertFalse(self.viewlet.available(), False)
+
+    def test_viewlet_with_unrelated_overrides(self):
+        with mock.patch(
+            "collective.regenv.browser.registry",
+            {"/other-site": {"foo": "bar"}},
+        ):
+            self.assertFalse(self.viewlet.available())
+
+    def test_viewlet_with_overrides(self):
+        with mock.patch(
+            "collective.regenv.browser.registry",
+            {"/".join(self.portal.getPhysicalPath()): {"foo": "bar"}},
+        ):
+            self.assertTrue(self.viewlet.available())
+
+    def test_viewlet_with_overrides_but_cookie_active(self):
+        with mock.patch(
+            "collective.regenv.browser.registry",
+            {"/".join(self.portal.getPhysicalPath()): {"foo": "bar"}},
+        ):
+            self.assertTrue(self.viewlet.available())
+
+            self.request.cookies[COLLECTIVE_REGENV_ACKNOWLEDGED] = "true"
+
+            self.assertFalse(self.viewlet.available())
+
+    def test_view_that_sets_the_cookie(self):
+        # There is a view that can be used cookie to disable the viewlet
+        view = api.content.get_view(
+            "acknowledge_collective_regenv",
+            self.portal,
+            self.request,
+        )
+        view()
+        self.assertTrue(self.request.response.cookies[COLLECTIVE_REGENV_ACKNOWLEDGED])


### PR DESCRIPTION
Our primary use case for collective.regenv is a staging website copied from production where we customize some records.

Most of the time, the site is used by devs.

In these cases, I find it useful to declare to my colleagues that collective.regenv is active on the site.


